### PR TITLE
Меняет docker-image c tetraweb/php на node:12-buster

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: tetraweb/php
+image: node:12-buster
 
 pages:
   stage: deploy


### PR DESCRIPTION
Смотри #20 (https://github.com/prikhodkin/gulp_prikhodkin/issues/20)